### PR TITLE
docker/Dockerfile: initial creation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM osrf/ros:kinetic-desktop-xenial
+
+# install ros packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-kinetic-desktop-full=1.3.2-0* \
+    python-rosinstall python-catkin-tools libusb-dev ros-kinetic-robot-localization\
+    ros-kinetic-hector-gazebo-plugins ros-kinetic-joystick-drivers \
+    ros-kinetic-usb-cam ros-kinetic-rosserial-python ros-kinetic-rosserial-arduino \
+    ros-kinetic-multimaster-fkie ros-kinetic-grid-map ipython git \
+    && rm -rf /var/lib/apt/lists/*
+    
+#From https://github.com/BCLab-UNM/Swarmathon-Docs/blob/master/PreinstalledCompetitionPackages.md
+#ros-kinetic-desktop-full python-rosinstall python-catkin-tools ros-kinetic-robot-localization ros-kinetic-hector-gazebo-plugins ros-kinetic-joystick-drivers git qtcreator libcap2-bin ros-kinetic-grid-map ros-kinetic-rosserial-python ros-kinetic-rosserial-arduino ros-kinetic-usb-cam ros-kinetic-multimaster-fkie ros-kinetic-rosbridge ros-kinetic-rosbridge-server
+RUN /bin/bash -c "mkdir -p /ChiliHouse/src"
+
+COPY . /ChiliHouse
+RUN chmod 777 /ChiliHouse
+
+RUN /bin/bash -c "source /opt/ros/kinetic/setup.bash; cd /ChiliHouse; ls -la; catkin clean; catkin init; catkin build; source ./devel/setup.bash; /ChiliHouse/run.sh"
+


### PR DESCRIPTION
am able to compile the code `docker build -f ./docker/Dockerfile . -t ChiliHouse`

I'm missing something currently unable to open the anything using the xserver inside the container
`docker run -it --env="DISPLAY"=$DISPLAY chilihouse`

Even tried `xhost local:root` and `xhost +local:docker` note: not recommended and should not be necessary

Almost `docker run -ti --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix/:/tmp/.X11-unix chilihouse`
very close
`docker run -ti --rm -e DISPLAY=:1 -v /tmp/.X11-unix/:/tmp/.X11-unix --ipc host chilihouse /usr/bin/gazebo`
```bash
libGL error: No matching fbConfigs or visuals found
libGL error: No matching fbConfigs or visuals found
libGL error: failed to load driver: swrast
libGL error: failed to load driver: swrast
```